### PR TITLE
Removed dependency to global electron

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,7 +19,7 @@ $ lein cooper
 $ electron . # in another tab
 #+END_SRC
 
-In case you don't have electron installed globally, run `npm run start`.
+In case you don't have electron installed globally, run =npm run start=.
 
 * Todos, roughly sorted by ascending awesomeness*difficulty
 

--- a/README.org
+++ b/README.org
@@ -19,6 +19,8 @@ $ lein cooper
 $ electron . # in another tab
 #+END_SRC
 
+In case you don't have electron installed globally, run `npm run start`.
+
 * Todos, roughly sorted by ascending awesomeness*difficulty
 
 - Better state cleanup for reloading

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "hello-world",
   "version": "0.1.0",
   "main": "resources/main.js",
+  "scripts": {
+    "start": "./node_modules/.bin/electron ."
+  },
   "dependencies": {
     "react": "^15.2.1",
     "react-bootstrap": "^0.31.0",
     "react-codemirror2": "0.0.9",
     "react-dom": "^15.2.1"
+  },
+  "devDependencies": {
+    "electron": "^1.6.11"
   }
 }


### PR DESCRIPTION
With this commit users don't need to have electron installed globally (which is not documented) but can simply execute a npm task (or yarn, you know whatever)